### PR TITLE
chore: update ash_csv package version in Readme Installation section

### DIFF
--- a/documentation/tutorials/getting-started-with-ash-csv.md
+++ b/documentation/tutorials/getting-started-with-ash-csv.md
@@ -7,7 +7,7 @@ AshCsv offers basic support for storing and reading resources from csv files.
 Add `ash_csv` to your list of dependencies in `mix.exs`:
 
 ```elixir
-{:ash_csv, "~> 0.9.7-rc.0"}
+{:ash_csv, "~> 0.9.7"}
 ```
 
 For information on how to configure it, see the [DSL documentation.](/documentation/dsls/DSL:-AshCsv.DataLayer.md)


### PR DESCRIPTION
Just happened to notice there is a newer version.

To be honest, I am not sure if the docs are updated before the next release (which would change the version number again).