### PR TITLE
docs: Fix example with separator

### DIFF
--- a/documentation/dsls/DSL:-AshCsv.DataLayer.md
+++ b/documentation/dsls/DSL:-AshCsv.DataLayer.md
@@ -17,7 +17,7 @@ csv do
   file "priv/data/tags.csv"
   create? true
   header? true
-  separator '-'
+  separator ?;
   columns [:id, :name]
 end
 


### PR DESCRIPTION
Adjust the example for separator to be a number.

I have executed `mix spark.cheat_sheets` to fix it.

### Contributor checklist

- [ ] My commit messages follow the [Conventional Commit Message Format](https://gist.github.com/stephenparish/9941e89d80e2bc58a153#format-of-the-commit-message)
      For example: `fix: Multiply by appropriate coefficient`, or
      `feat(Calculator): Correctly preserve history`
      Any explanation or long form information in your commit message should be
      in a separate paragraph, separated by a blank line from the primary message
- [ ] Bug fixes include regression tests
- [ ] Features include unit/acceptance tests
